### PR TITLE
Changing interval as minutes instead of seconds

### DIFF
--- a/src/molecules/Interval.tsx
+++ b/src/molecules/Interval.tsx
@@ -6,15 +6,15 @@ import "./Interval.css";
 
 const Interval: React.FunctionComponent<{
   onIntervalChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  interval: number;
-}> = ({ onIntervalChange, interval }) => {
+  intervalMinutes: number;
+}> = ({ onIntervalChange, intervalMinutes }) => {
   return (
     <div className="interval">
-      <div className="interval--text">Interval (sec)&nbsp;:&nbsp;</div>
+      <div className="interval--text">Interval (minutes)&nbsp;:&nbsp;</div>
       <TextInput
         onChange={onIntervalChange}
         type="number"
-        value={interval}
+        value={intervalMinutes}
         min={1}
       />
     </div>

--- a/src/organisms/Session.tsx
+++ b/src/organisms/Session.tsx
@@ -10,14 +10,14 @@ const Session: React.FunctionComponent<{
   onStartOrPause: (event: React.MouseEvent<HTMLElement>) => void;
   onReset: (event: React.MouseEvent<HTMLElement>) => void;
   onIntervalChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  interval: number;
+  intervalMinutes: number;
   disableStartOrPause: boolean;
 }> = ({
   elapsedTime,
   onStartOrPause,
   onReset,
   onIntervalChange,
-  interval,
+  intervalMinutes,
   disableStartOrPause
 }) => {
   return (
@@ -29,7 +29,10 @@ const Session: React.FunctionComponent<{
         disableStartOrPause={disableStartOrPause}
       />
       <div className="session--divider" />
-      <Interval onIntervalChange={onIntervalChange} interval={interval} />
+      <Interval
+        onIntervalChange={onIntervalChange}
+        intervalMinutes={intervalMinutes}
+      />
     </div>
   );
 };

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -5,17 +5,19 @@ import { setCookieUsers, getCookieUsers } from "../utils/cookie";
 
 const emptyUsername = "";
 const blankStringsPattern = new RegExp(/^\s*$/);
-const initialIntervalSec = 60 * 30;
+const initialIntervalSeconds = 60 * 30;
 
 const AppContainer: React.FunctionComponent = () => {
   const count = React.useRef(0);
   const timerID = React.useRef<NodeJS.Timeout>();
-  const intervalSecRef = React.useRef(initialIntervalSec);
+  const intervalSecondsRef = React.useRef(initialIntervalSeconds);
   const [users, setUsers] = React.useState<string[]>(
     JSON.parse(getCookieUsers())
   );
   const [username, setUsername] = React.useState("");
-  const [intervalSec, setIntervalSec] = React.useState(initialIntervalSec);
+  const [intervalSeconds, setIntervalSeconds] = React.useState(
+    initialIntervalSeconds
+  );
 
   const [tickCount, setTickCount] = React.useState(0);
   const [showMenu, setShowMenu] = React.useState(false);
@@ -51,7 +53,7 @@ const AppContainer: React.FunctionComponent = () => {
     timerID.current = setInterval(() => {
       count.current += 1;
       setTickCount(count.current);
-      if (count.current % intervalSecRef.current === 0) {
+      if (count.current % intervalSecondsRef.current === 0) {
         if (timerID.current) {
           clearInterval(timerID.current);
           timerID.current = undefined;
@@ -91,9 +93,10 @@ const AppContainer: React.FunctionComponent = () => {
 
   const onIntervalChange = React.useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      const newInterval = parseInt(event.currentTarget.value);
-      setIntervalSec(newInterval);
-      intervalSecRef.current = newInterval;
+      const newIntervalMinutes = parseInt(event.currentTarget.value);
+      const newIntervalSeconds = newIntervalMinutes * 60;
+      setIntervalSeconds(newIntervalSeconds);
+      intervalSecondsRef.current = newIntervalSeconds;
     },
     []
   );
@@ -145,7 +148,7 @@ const AppContainer: React.FunctionComponent = () => {
       onHamburgerMenuCloseClick={onHamburgerMenuCloseClick}
       username={username}
       users={users}
-      interval={intervalSec}
+      intervalMinutes={Math.ceil(intervalSeconds / 60)}
       registerDisabled={registerDisabled()}
       showMenu={showMenu}
     ></AppComponent>

--- a/src/templates/AppComponent.tsx
+++ b/src/templates/AppComponent.tsx
@@ -20,7 +20,7 @@ const AppComponent: React.FunctionComponent<{
   onHamburgerMenuCloseClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   username: string;
   users: string[];
-  interval: number;
+  intervalMinutes: number;
   registerDisabled: boolean;
   showMenu: boolean;
 }> = ({
@@ -36,7 +36,7 @@ const AppComponent: React.FunctionComponent<{
   onHamburgerMenuCloseClick,
   username,
   users,
-  interval,
+  intervalMinutes,
   registerDisabled,
   showMenu
 }) => {
@@ -64,7 +64,7 @@ const AppComponent: React.FunctionComponent<{
             onStartOrPause={onStartOrPause}
             onReset={onReset}
             onIntervalChange={onIntervalChange}
-            interval={interval}
+            intervalMinutes={intervalMinutes}
             disableStartOrPause={users.length < 2}
           />
         </div>


### PR DESCRIPTION
Why
---

I often use this tool, then all teammates says `Why handling seconds? Hmm... we want to use 30 minutes then ... so ... 1800 seconds is the correct value!`

This is needless step 😄 

When I implemented current code in https://github.com/pankona/mobu/pull/8, handling seconds is so useful to ensure behavior, it is just a development reason.
Now is the time to change it, I think. 🕐 

Before
---

<img width="1271" alt="スクリーンショット 2021-02-16 4 31 34" src="https://user-images.githubusercontent.com/1180335/107988115-ac74f380-7012-11eb-998f-047edd16c8f6.png">

After
---

<img width="1257" alt="スクリーンショット 2021-02-16 4 46 48" src="https://user-images.githubusercontent.com/1180335/107988122-ae3eb700-7012-11eb-87e2-a8d33a8cd69b.png">
