### PR TITLE
add an iteration counter (#25)

### DIFF
--- a/src/molecules/Timer.tsx
+++ b/src/molecules/Timer.tsx
@@ -8,13 +8,21 @@ import "../atoms/Button.css";
 
 const Timer: React.FunctionComponent<{
   elapsedTime: string;
+  iterationCount: number;
   onStartOrPause: (event: React.MouseEvent<HTMLElement>) => void;
   onReset: (event: React.MouseEvent<HTMLElement>) => void;
   disableStartOrPause: boolean;
-}> = ({ elapsedTime, onStartOrPause, onReset, disableStartOrPause }) => {
+}> = ({
+  elapsedTime,
+  iterationCount,
+  onStartOrPause,
+  onReset,
+  disableStartOrPause,
+}) => {
   return (
     <>
-      <Text>Elapsed time: {elapsedTime}</Text>
+      <Text>elapsed time: {elapsedTime}</Text>
+      <Text>(iteration: {iterationCount})</Text>
       <div className="timer--divider" />
       <Button
         className="button--width-max"

--- a/src/organisms/Session.tsx
+++ b/src/organisms/Session.tsx
@@ -6,6 +6,7 @@ import Interval from "../molecules/Interval";
 import "./Session.css";
 
 const Session: React.FunctionComponent<{
+  iterationCount: number;
   elapsedTime: string;
   onStartOrPause: (event: React.MouseEvent<HTMLElement>) => void;
   onReset: (event: React.MouseEvent<HTMLElement>) => void;
@@ -13,6 +14,7 @@ const Session: React.FunctionComponent<{
   intervalMinutes: number;
   disableStartOrPause: boolean;
 }> = ({
+  iterationCount,
   elapsedTime,
   onStartOrPause,
   onReset,
@@ -23,6 +25,7 @@ const Session: React.FunctionComponent<{
   return (
     <div className="session">
       <Timer
+        iterationCount={iterationCount}
         elapsedTime={elapsedTime}
         onStartOrPause={onStartOrPause}
         onReset={onReset}

--- a/src/pages/AppContainer.tsx
+++ b/src/pages/AppContainer.tsx
@@ -20,6 +20,7 @@ const AppContainer: React.FunctionComponent = () => {
   );
 
   const [tickCount, setTickCount] = React.useState(0);
+  const [iterationCount, setIterationCount] = React.useState(1);
   const [showMenu, setShowMenu] = React.useState(false);
 
   const registerDisabled = () =>
@@ -54,6 +55,7 @@ const AppContainer: React.FunctionComponent = () => {
       count.current += 1;
       setTickCount(count.current);
       if (count.current % intervalSecondsRef.current === 0) {
+        setIterationCount(count.current / intervalSecondsRef.current + 1);
         if (timerID.current) {
           clearInterval(timerID.current);
           timerID.current = undefined;
@@ -74,6 +76,7 @@ const AppContainer: React.FunctionComponent = () => {
   const onReset = React.useCallback(() => {
     count.current = 0;
     setTickCount(count.current);
+    setIterationCount(1);
   }, [count]);
 
   const onShuffle = React.useCallback(() => {
@@ -137,6 +140,7 @@ const AppContainer: React.FunctionComponent = () => {
   return (
     <AppComponent
       elapsedTime={numberToTimeString(tickCount)}
+      iterationCount={iterationCount}
       onStartOrPause={onStartOrPause}
       onReset={onReset}
       onShuffle={onShuffle}

--- a/src/templates/AppComponent.tsx
+++ b/src/templates/AppComponent.tsx
@@ -9,6 +9,7 @@ import "./AppComponent.css";
 
 const AppComponent: React.FunctionComponent<{
   elapsedTime: string;
+  iterationCount: number;
   onStartOrPause: (event: React.MouseEvent<HTMLElement>) => void;
   onReset: (event: React.MouseEvent<HTMLElement>) => void;
   onShuffle: (event: React.MouseEvent<HTMLButtonElement>) => void;
@@ -25,6 +26,7 @@ const AppComponent: React.FunctionComponent<{
   showMenu: boolean;
 }> = ({
   elapsedTime,
+  iterationCount,
   onStartOrPause,
   onReset,
   onShuffle,
@@ -61,6 +63,7 @@ const AppComponent: React.FunctionComponent<{
           <div className="divider"></div>
           <Session
             elapsedTime={elapsedTime}
+            iterationCount={iterationCount}
             onStartOrPause={onStartOrPause}
             onReset={onReset}
             onIntervalChange={onIntervalChange}


### PR DESCRIPTION
Seeing the reminder, I implemented the initial idea of iteration counter (*1) which is indicated in https://github.com/pankona/mobu/issues/25.

![f562294580c2041f360e92062e8c547c](https://user-images.githubusercontent.com/7314191/110655491-72a69f80-8202-11eb-9728-57bfd56c851f.gif)

The counter is displayed with label `iteration: ` between the time counter and `Start/Pause` button.
`Reset` will set the counter to 1 as it sets elapsed time to 00:00:00.

This might not be an optimal solution but I created a PR to illustrate the use case.

*1: Originally I used the expression "interval counter" but thought twice as it might be confused the time width(e.g. "25 / 30 minutes")